### PR TITLE
[Docker] Use Python offical image as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
-from ubuntu:18.04
-ENV DEBIAN_FRONTEND=noninteractive
+FROM python:3.7.4
 
-#install prerequisites
-RUN apt-get -q update && \
-    apt-get -q -y install python3 python3-pip && \
-    pip3 install pyrabbit boto3 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/ /var/cache/apt/ /var/cache/debconf/
+RUN pip install pyrabbit boto3
 
 ADD publish_queue_size.py /opt
 
-CMD "/opt/publish_queue_size.py"
+CMD /opt/publish_queue_size.py


### PR DESCRIPTION
It makes the image more simple